### PR TITLE
[feat] 헤더의 모바일용 메인 메뉴추가

### DIFF
--- a/app/(anon)/components/MobileSlideMenu.module.scss
+++ b/app/(anon)/components/MobileSlideMenu.module.scss
@@ -1,0 +1,104 @@
+// 모바일 슬라이드 메뉴 오버레이
+.overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	display: flex;
+	align-items: flex-end;
+	animation: fadeIn 0.3s ease-out;
+}
+
+// 모바일 슬라이드 메뉴 컨테이너
+.slideContainer {
+	width: 100%;
+	border-top-left-radius: 16px;
+	border-top-right-radius: 16px;
+	padding: 24px 30px 40px;
+	padding-bottom: 80px; // 하단 요소 고려
+	transform: translateY(100%);
+	transition: transform 0.3s ease-out;
+	animation: slideUp 0.3s ease-out forwards;
+}
+
+// 모바일 슬라이드 메뉴가 열렸을 때
+.open {
+	transform: translateY(0);
+}
+
+// 헤더 영역
+.header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 20px;
+	padding-bottom: 16px;
+	border-bottom: 1px solid var(--color-base-7);
+}
+
+// 제목
+.title {
+	color: var(--color-base-1);
+	font-size: 18px;
+	font-weight: 600;
+	margin: 0;
+}
+
+// 닫기 버튼
+.closeButton {
+	color: var(--color-base-1);
+	background: none;
+	border: none;
+	cursor: pointer;
+	font-size: 24px;
+	width: 32px;
+	height: 32px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 4px;
+	transition: background-color 0.2s ease;
+
+	&:hover {
+		background-color: var(--color-base-8);
+	}
+
+	&:active {
+		background-color: var(--color-base-7);
+	}
+}
+
+// 콘텐츠 영역
+.content {
+	color: var(--color-base-1);
+}
+
+// 애니메이션
+@keyframes fadeIn {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes slideUp {
+	from {
+		transform: translateY(100%);
+	}
+	to {
+		transform: translateY(0);
+	}
+}
+
+// 반응형 조정
+@media (min-width: 768px) {
+	.slideContainer {
+		max-width: 400px;
+		margin: 0 auto;
+		border-radius: 16px;
+		margin-bottom: 20px;
+	}
+}

--- a/app/(anon)/components/MobileSlideMenu.tsx
+++ b/app/(anon)/components/MobileSlideMenu.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import React, { ReactNode } from "react";
+import styles from "./MobileSlideMenu.module.scss";
+
+interface MobileSlideMenuProps {
+	isOpen: boolean;
+	onClose: () => void;
+	children: ReactNode;
+	title?: string;
+	overlayColor?: string;
+	backgroundColor?: string;
+	zIndex?: number;
+}
+
+const MobileSlideMenu: React.FC<MobileSlideMenuProps> = ({
+	isOpen,
+	onClose,
+	children,
+	title,
+	overlayColor = "rgba(0, 0, 0, 0.5)",
+	backgroundColor = "var(--color-base-9)",
+	zIndex = 1001,
+}) => {
+	if (!isOpen) return null;
+
+	return (
+		<div
+			className={styles.overlay}
+			onClick={onClose}
+			style={{
+				backgroundColor: overlayColor,
+				zIndex: zIndex,
+			}}
+		>
+			<div
+				className={`${styles.slideContainer} ${isOpen ? styles.open : ""}`}
+				onClick={(e) => e.stopPropagation()}
+				style={{ backgroundColor: backgroundColor }}
+			>
+				{title && (
+					<div className={styles.header}>
+						<h2 className={styles.title}>{title}</h2>
+						<button
+							className={styles.closeButton}
+							onClick={onClose}
+							aria-label="메뉴 닫기"
+						>
+							×
+						</button>
+					</div>
+				)}
+				<div className={styles.content}>{children}</div>
+			</div>
+		</div>
+	);
+};
+
+export default MobileSlideMenu;

--- a/app/(anon)/components/MobileSlideMenuExample.tsx
+++ b/app/(anon)/components/MobileSlideMenuExample.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import MobileSlideMenu from "./MobileSlideMenu";
+
+// MobileSlideMenu 사용 예시 컴포넌트
+const MobileSlideMenuExample: React.FC = () => {
+	const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+	const openMenu = () => setIsMenuOpen(true);
+	const closeMenu = () => setIsMenuOpen(false);
+
+	return (
+		<div>
+			{/* 메뉴 열기 버튼 */}
+			<button
+				onClick={openMenu}
+				className="n-icon n-icon:menu n-icon-color:base-1"
+			>
+				메뉴 열기
+			</button>
+
+			{/* MobileSlideMenu 컴포넌트 사용 */}
+			<MobileSlideMenu
+				isOpen={isMenuOpen}
+				onClose={closeMenu}
+				title="메뉴"
+				zIndex={1001}
+			>
+				<nav>
+					<ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+						<li
+							style={{
+								margin: "16px 0",
+								borderBottom: "1px solid var(--color-base-7)",
+							}}
+						>
+							<Link
+								href="/"
+								onClick={closeMenu}
+								className="n-icon n-icon:home n-icon-color:base-1"
+								style={{
+									color: "var(--color-base-1)",
+									textDecoration: "none",
+									display: "flex",
+									alignItems: "center",
+									gap: "12px",
+									padding: "16px 0",
+									fontSize: "16px",
+									fontWeight: "500",
+								}}
+							>
+								홈
+							</Link>
+						</li>
+						<li
+							style={{
+								margin: "16px 0",
+								borderBottom: "1px solid var(--color-base-7)",
+							}}
+						>
+							<Link
+								href="/admin"
+								onClick={closeMenu}
+								className="n-icon n-icon:dashboard n-icon-color:base-1"
+								style={{
+									color: "var(--color-base-1)",
+									textDecoration: "none",
+									display: "flex",
+									alignItems: "center",
+									gap: "12px",
+									padding: "16px 0",
+									fontSize: "16px",
+									fontWeight: "500",
+								}}
+							>
+								대시보드
+							</Link>
+						</li>
+						<li style={{ margin: "16px 0" }}>
+							<Link
+								href="/login"
+								onClick={closeMenu}
+								className="n-icon n-icon:login n-icon-color:base-1"
+								style={{
+									color: "var(--color-base-1)",
+									textDecoration: "none",
+									display: "flex",
+									alignItems: "center",
+									gap: "12px",
+									padding: "16px 0",
+									fontSize: "16px",
+									fontWeight: "500",
+								}}
+							>
+								로그인
+							</Link>
+						</li>
+					</ul>
+				</nav>
+			</MobileSlideMenu>
+		</div>
+	);
+};
+
+export default MobileSlideMenuExample;

--- a/app/(anon)/components/RootHeader.tsx
+++ b/app/(anon)/components/RootHeader.tsx
@@ -2,7 +2,9 @@
 import Link from "next/link";
 import { signOut, useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import styles from "./RootHeader.module.scss";
+import MobileSlideMenu from "./MobileSlideMenu";
 
 // 스타일 모듈을 쉽게 사용하기 위해 destructuring & camel 표기로 매핑
 const {
@@ -14,6 +16,7 @@ const {
 const RootHeader = () => {
 	const { data: session, status } = useSession();
 	const router = useRouter();
+	const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
 	console.log("=== header test session print===");
 	console.log("RootHeader Session:", session);
@@ -24,48 +27,167 @@ const RootHeader = () => {
 		e.preventDefault();
 		await signOut({ redirect: false });
 		router.push("/");
+		setIsMobileMenuOpen(false); // 메뉴 닫기
+	};
+
+	const toggleMobileMenu = () => {
+		setIsMobileMenuOpen(!isMobileMenuOpen);
+	};
+
+	const closeMobileMenu = () => {
+		setIsMobileMenuOpen(false);
 	};
 
 	return (
-		<header className={`${header}`}>
-			<h1>
-				<Link href="/">NCafe</Link>
-			</h1>
-			<div className={topMobileMenu}>
-				<Link className="n-icon n-icon:menu n-icon-color:base-1" href="#">
-					숨김버튼
-				</Link>
-			</div>
-			<div className={topMenu}>
+		<>
+			<header className={`${header}`}>
+				<h1>
+					<Link href="/">NCafe</Link>
+				</h1>
+				<div className={topMobileMenu}>
+					<button
+						className="n-icon n-icon:menu n-icon-color:base-1 color:base-1"
+						onClick={toggleMobileMenu}
+						aria-label="메뉴 열기"
+					>
+						메뉴
+					</button>
+				</div>
+				<div className={topMenu}>
+					<nav>
+						<h1 className="d:none">상단메뉴</h1>
+						<ul>
+							<li>
+								<Link
+									className="n-icon n-icon:home n-icon-color:base-1"
+									href="/"
+								>
+									홈
+								</Link>
+							</li>
+							<li>
+								<Link
+									className="n-icon n-icon:dashboard n-icon-color:base-1"
+									href="/admin"
+								>
+									대시보드
+								</Link>
+							</li>
+							<li>
+								{session ? (
+									<Link
+										className="n-icon n-icon:logout n-icon-color:base-1"
+										href="#"
+										onClick={handleSignOut}
+									>
+										로그아웃
+									</Link>
+								) : (
+									<Link
+										className="n-icon n-icon:login n-icon-color:base-1"
+										href="/login"
+									>
+										로그인
+									</Link>
+								)}
+							</li>
+						</ul>
+					</nav>
+				</div>
+			</header>
+
+			{/* MobileSlideMenu 컴포넌트 사용 */}
+			<MobileSlideMenu
+				isOpen={isMobileMenuOpen}
+				onClose={closeMobileMenu}
+				title="메뉴"
+				zIndex={1001}
+			>
 				<nav>
-					<h1 className="d:none">상단메뉴</h1>
-					<ul>
-						<li>
-							<Link className="n-icon n-icon:home n-icon-color:base-1" href="/">
+					<h1 className="d:none">모바일 메뉴</h1>
+					<ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+						<li
+							style={{
+								margin: "16px 0",
+								borderBottom: "1px solid var(--color-base-7)",
+							}}
+						>
+							<Link
+								href="/"
+								onClick={closeMobileMenu}
+								className="n-icon n-icon:home n-icon-color:base-1 n-deco"
+								style={{
+									color: "var(--color-base-1)",
+									textDecoration: "none",
+									display: "flex",
+									alignItems: "center",
+									gap: "12px",
+									padding: "16px 0",
+									fontSize: "16px",
+									fontWeight: "500",
+								}}
+							>
 								홈
 							</Link>
 						</li>
-						<li>
+						<li
+							style={{
+								margin: "16px 0",
+								borderBottom: "1px solid var(--color-base-7)",
+							}}
+						>
 							<Link
-								className="n-icon n-icon:dashboard n-icon-color:base-1"
 								href="/admin"
+								onClick={closeMobileMenu}
+								className="n-icon n-icon:dashboard n-icon-color:base-1 n-deco"
+								style={{
+									color: "var(--color-base-1)",
+									textDecoration: "none",
+									display: "flex",
+									alignItems: "center",
+									gap: "12px",
+									padding: "16px 0",
+									fontSize: "16px",
+									fontWeight: "500",
+								}}
 							>
 								대시보드
 							</Link>
 						</li>
-						<li>
+						<li style={{ margin: "16px 0" }}>
 							{session ? (
 								<Link
-									className="n-icon n-icon:logout n-icon-color:base-1"
 									href="#"
 									onClick={handleSignOut}
+									className="n-icon n-icon:logout n-icon-color:base-1 n-deco"
+									style={{
+										color: "var(--color-base-1)",
+										textDecoration: "none",
+										display: "flex",
+										alignItems: "center",
+										gap: "12px",
+										padding: "16px 0",
+										fontSize: "16px",
+										fontWeight: "500",
+									}}
 								>
 									로그아웃
 								</Link>
 							) : (
 								<Link
-									className="n-icon n-icon:login n-icon-color:base-1"
 									href="/login"
+									onClick={closeMobileMenu}
+									className="n-icon n-icon:login n-icon-color:base-1 n-deco"
+									style={{
+										color: "var(--color-base-1)",
+										textDecoration: "none",
+										display: "flex",
+										alignItems: "center",
+										gap: "12px",
+										padding: "16px 0",
+										fontSize: "16px",
+										fontWeight: "500",
+									}}
 								>
 									로그인
 								</Link>
@@ -73,8 +195,8 @@ const RootHeader = () => {
 						</li>
 					</ul>
 				</nav>
-			</div>
-		</header>
+			</MobileSlideMenu>
+		</>
 	);
 };
 

--- a/app/(anon)/layout.tsx
+++ b/app/(anon)/layout.tsx
@@ -12,7 +12,7 @@ export default async function AnonLayout({
 	const session = await getServerSession(authOptions);
 
 	return (
-		<div>
+		<div className="d:flex flex-direction:column h:100p">
 			<NextAuthSessionProvider session={session}>
 				<RootHeader />
 				{children}

--- a/app/api/auth/[...nextauth]/authOptions.ts
+++ b/app/api/auth/[...nextauth]/authOptions.ts
@@ -42,8 +42,8 @@ export const authOptions = {
 
 				try {
 					const loginUsecase = new LoginUsecase(new PrMemberRepository());
-					const request = new LoginRequestDto(username, password);
-					const result = await loginUsecase.execute(request);
+					const loginRequestdto = new LoginRequestDto(username, password);
+					const result = await loginUsecase.execute(loginRequestdto);
 
 					console.log("📋 LoginUsecase 결과:", JSON.stringify(result, null, 2));
 


### PR DESCRIPTION
### feat: 모바일 슬라이드 메뉴 컴포넌트 추가 및 헤더 연동

#### 주요 변경사항
- 하단에서 올라오는 모바일 메뉴 UI 구현(슬라이드 업)
- 오버레이 클릭, 메뉴 항목 클릭 시 닫힘 처리
- 장바구니 영역과 겹치지 않도록 하단 여백 및 z-index 조정
- 데스크톱 뷰(≥ 922px)에서는 기존 상단 메뉴 유지

#### 추가/수정 파일
- `app/(anon)/components/MobileSlideMenu.tsx` — 범용 슬라이드 메뉴 컴포넌트
- `app/(anon)/components/MobileSlideMenu.module.scss` — 슬라이드/오버레이/컨텐츠 스타일
- `app/(anon)/components/MobileSlideMenuExample.tsx` — 사용 예시(학습/참고용)
- `app/(anon)/components/RootHeader.tsx` — 햄버거 버튼 + `MobileSlideMenu` 연동

#### UX/동작
- 햄버거 버튼 클릭 → 하단 슬라이드 업으로 메뉴 표시
- 오버레이 영역 클릭 또는 메뉴 항목 클릭 → 메뉴 닫힘
- 세로 리스트는 아이콘/텍스트가 구분선 기준 중앙 정렬

#### 테스트 방법
1. 뷰포트를 모바일(폭 < 922px)로 변경
2. 헤더의 햄버거 버튼 클릭 → 메뉴가 하단에서 부드럽게 등장하는지 확인
3. 메뉴 항목 클릭 시 메뉴가 닫히는지 확인
4. 오버레이 클릭 시 닫히는지 확인
5. 장바구니 UI와 시각적으로 겹치지 않는지 확인
6. 데스크톱(폭 ≥ 922px)에서는 기존 상단 메뉴가 정상 노출되는지 확인

#### 고려 사항
- 브레이킹 체인지: 없음
- 환경 변수/마이그레이션: 없음
- 접근성: 버튼에 `aria-label` 적용, 키보드 포커스 기본 동작 유지

필요 시, `MobileSlideMenuExample.tsx`는 병합 전 제거 가능(참고용).